### PR TITLE
feat: add support for opening channels and asserting on messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules
 
 # Library
 dist
+
+# Jest
+coverage

--- a/src/__tests__/slack-testing-library.test.ts
+++ b/src/__tests__/slack-testing-library.test.ts
@@ -1,7 +1,24 @@
-import { createServer, Server } from "http";
+import { View } from "@slack/types";
+import { Message } from "@slack/web-api/dist/response/ChatScheduleMessageResponse";
+import { Server } from "http";
 import { SlackTestingLibrary } from "../slack-testing-library";
+import { startServer } from "../util/server";
 
+jest.mock("../util/server");
 jest.mock("http");
+
+export const createMockServer = ({
+  listen,
+  close,
+}: Partial<{
+  listen: (port: number, cb: Function) => void;
+  close: (cb: Function) => void;
+}> = {}): Server => {
+  return {
+    listen: listen || ((_port: number, cb: Function) => cb()),
+    close: close || (() => {}),
+  } as unknown as Server;
+};
 
 describe("SlackTestingLibrary", () => {
   beforeEach(() => {
@@ -10,7 +27,7 @@ describe("SlackTestingLibrary", () => {
 
   describe("constructor", () => {
     it("should return an instance of SlackTestingLibrary when correctly initialized", () => {
-      const slackTestingLibrary = new SlackTestingLibrary({
+      const sl = new SlackTestingLibrary({
         baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
         actor: {
           teamId: "T1234567",
@@ -19,65 +36,228 @@ describe("SlackTestingLibrary", () => {
         port: 3840,
       });
 
-      expect(slackTestingLibrary instanceof SlackTestingLibrary).toBe(true);
+      expect(sl instanceof SlackTestingLibrary).toBe(true);
     });
   });
 
   describe("#init()", () => {
     it("should create a HTTP server and start listening when called", async () => {
-      const slackTestingLibrary = new SlackTestingLibrary({
+      const sl = new SlackTestingLibrary({
         baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
       });
-      (createServer as jest.Mock<Server>).mockImplementation(() => {
-        return {
-          listen: (_port: number, cb: Function) => cb(),
-        } as unknown as Server;
-      });
 
-      await slackTestingLibrary.init();
+      (startServer as jest.Mock<Promise<Server>>).mockImplementation(async () =>
+        createMockServer()
+      );
 
-      expect(createServer).toHaveBeenCalled();
+      await sl.init();
+
+      expect(startServer).toHaveBeenCalledWith(
+        expect.objectContaining({ port: 8123 })
+      );
     });
 
     it("should listen on a custom port if provided", async () => {
-      const slackTestingLibrary = new SlackTestingLibrary({
+      const sl = new SlackTestingLibrary({
         baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
         port: 4001,
       });
-      const mockListen = jest.fn((_port, cb) => cb());
 
-      (createServer as jest.Mock<Server>).mockImplementation(() => {
-        return {
-          listen: mockListen,
-        } as unknown as Server;
-      });
+      (startServer as jest.Mock<Promise<Server>>).mockImplementation(async () =>
+        createMockServer()
+      );
 
-      await slackTestingLibrary.init();
+      await sl.init();
 
-      expect(mockListen).toHaveBeenCalledWith(4001, expect.any(Function));
+      expect(startServer).toHaveBeenCalledWith(
+        expect.objectContaining({ port: 4001 })
+      );
     });
   });
 
   describe("#teardown()", () => {
     it("should stop the server if one is running", async () => {
-      const slackTestingLibrary = new SlackTestingLibrary({
+      const sl = new SlackTestingLibrary({
         baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
       });
 
       const mockClose = jest.fn((cb) => cb());
 
-      (createServer as jest.Mock<Server>).mockImplementation(() => {
-        return {
-          listen: (_port: number, cb: Function) => cb(),
+      (startServer as jest.Mock<Promise<Server>>).mockImplementation(async () =>
+        createMockServer({
           close: mockClose,
-        } as unknown as Server;
-      });
+        })
+      );
 
-      await slackTestingLibrary.init();
+      await sl.init();
 
-      await slackTestingLibrary.teardown();
+      await sl.teardown();
 
       expect(mockClose).toHaveBeenCalled();
+    });
+  });
+
+  describe("#getByText()", () => {
+    it("should throw an error if the server hasn't been initialised", async () => {
+      const sl = new SlackTestingLibrary({
+        baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
+      });
+
+      await expect(sl.getByText("Sample")).rejects.toThrow(
+        "Start the Slack listening server first by awaiting `sl.init()`"
+      );
+    });
+  });
+
+  it("should throw an error if an active screen hasn't been set", async () => {
+    const sl = new SlackTestingLibrary({
+      baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
+    });
+
+    (startServer as jest.Mock<Promise<Server>>).mockImplementation(async () =>
+      createMockServer()
+    );
+
+    await sl.init();
+
+    await expect(sl.getByText("Sample")).rejects.toThrow("No active screen");
+  });
+
+  describe("activeScreen: view", () => {
+    it("should throw if the provided text isn't in the view", async () => {
+      const sl = new SlackTestingLibrary({
+        baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
+        actor: {
+          teamId: "T1234567",
+          userId: "U1234567",
+        },
+      });
+
+      (startServer as jest.Mock<Promise<Server>>).mockImplementation(
+        async ({ onViewChange }) => {
+          // Set the active screen
+          onViewChange({
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  text: "Match: 1234",
+                  type: "plain_text",
+                },
+              },
+            ],
+          } as View);
+
+          return createMockServer();
+        }
+      );
+
+      await sl.init();
+
+      await sl.openHome();
+
+      await expect(sl.getByText("Match: 5678")).rejects.toThrow(
+        'Unable to find the text "Match: 5678" in the current view'
+      );
+    });
+
+    it("should resolve if the provided text is in the view", async () => {
+      const sl = new SlackTestingLibrary({
+        baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
+        actor: {
+          teamId: "T1234567",
+          userId: "U1234567",
+        },
+      });
+
+      (startServer as jest.Mock<Promise<Server>>).mockImplementation(
+        async ({ onViewChange }) => {
+          // Set the active screen
+          onViewChange({
+            blocks: [
+              {
+                type: "section",
+                text: {
+                  text: "Match: 1234",
+                  type: "plain_text",
+                },
+              },
+            ],
+          } as View);
+
+          return createMockServer();
+        }
+      );
+
+      await sl.init();
+
+      await sl.openHome();
+
+      await sl.getByText("Match: 1234");
+    });
+  });
+
+  describe("activeScreen: channel", () => {
+    it("should throw if the provided text isn't in any messages in the channel", async () => {
+      const sl = new SlackTestingLibrary({
+        baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
+        actor: {
+          teamId: "T1234567",
+          userId: "U1234567",
+        },
+      });
+
+      (startServer as jest.Mock<Promise<Server>>).mockImplementation(
+        async ({ onRecieveMessage }) => {
+          // Add to the message log
+          onRecieveMessage(
+            {
+              text: "Match: 1234",
+            } as Message,
+            "C1234567"
+          );
+
+          return createMockServer();
+        }
+      );
+
+      await sl.init();
+
+      await sl.openChannel("C1234567");
+
+      await expect(sl.getByText("Match: 5678")).rejects.toThrow(
+        'Unable to find the text "Match: 5678" in the current channel'
+      );
+    });
+
+    it("should resolve if the provided text is in the view", async () => {
+      const sl = new SlackTestingLibrary({
+        baseUrl: "https://www.github.com/chrishutchinson/slack-testing-library",
+        actor: {
+          teamId: "T1234567",
+          userId: "U1234567",
+        },
+      });
+
+      (startServer as jest.Mock<Promise<Server>>).mockImplementation(
+        async ({ onRecieveMessage }) => {
+          // Add to the message log
+          onRecieveMessage(
+            {
+              text: "Match: 1234",
+            } as Message,
+            "C1234567"
+          );
+
+          return createMockServer();
+        }
+      );
+
+      await sl.init();
+
+      await sl.openChannel("C1234567");
+
+      await sl.getByText("Match: 1234");
     });
   });
 });

--- a/src/fixture-generator.ts
+++ b/src/fixture-generator.ts
@@ -1,4 +1,4 @@
-import { SlackChannel } from "./types";
+import { SlackChannel, SlackTeam } from "./types";
 
 export class SlackTestingLibraryFixtureGenerator {
   static buildChannel(overrides: Partial<SlackChannel> = {}): SlackChannel {
@@ -38,6 +38,14 @@ export class SlackTestingLibraryFixtureGenerator {
         last_set: 0,
       },
       unlinked: 0,
+      ...overrides,
+    };
+  }
+
+  static buildTeam(overrides: Partial<SlackTeam> = {}): SlackTeam {
+    return {
+      id: "T12345678",
+      name: "team-name",
       ...overrides,
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,26 @@ export type SlackChannel = {
   num_members: number;
 };
 
-export interface SlackEvent {
+export type SlackTeam = {
+  id: string;
+  name: string;
+};
+
+interface BaseSlackEvent {
   type: string;
-  event_ts: string;
+  event_ts: number;
+}
+export interface SlackEvent<T extends BaseSlackEvent> {
+  type: string;
+  team_id: string;
+  event: T;
+}
+
+export interface AppMentionEvent extends BaseSlackEvent {
+  type: "app_mention";
+  user: string;
+  text: string;
+  ts: string;
+  team: string;
+  channel: string;
 }

--- a/src/util/__tests__/parse-slack-request.test.ts
+++ b/src/util/__tests__/parse-slack-request.test.ts
@@ -1,8 +1,10 @@
 import { parseSlackRequest } from "../parse-slack-request";
 
 describe("#parseSlackRequest()", () => {
-  it("should return an empty objet for an unknown request type", () => {
-    expect(parseSlackRequest("/some/unknown/url", {})).toEqual({});
+  it("should return an unknown type for an unknown request type", () => {
+    expect(parseSlackRequest("/some/unknown/url", {})).toEqual({
+      type: "unknown",
+    });
   });
 
   it("should return the parsed view for a views.publish request", () => {
@@ -13,8 +15,34 @@ describe("#parseSlackRequest()", () => {
         }),
       })
     ).toEqual({
+      type: "view",
       view: {
         example: "view",
+      },
+    });
+  });
+
+  it("should return the channel, parsed blocks and text for a chat.postMessage request", () => {
+    expect(
+      parseSlackRequest("/slack/api/chat.postMessage", {
+        channel: "C12345678",
+        blocks: JSON.stringify([
+          {
+            type: "section",
+          },
+        ]),
+        text: "Some text",
+      })
+    ).toEqual({
+      type: "message",
+      channel: "C12345678",
+      message: {
+        blocks: [
+          {
+            type: "section",
+          },
+        ],
+        text: "Some text",
       },
     });
   });

--- a/src/util/__tests__/server.test.ts
+++ b/src/util/__tests__/server.test.ts
@@ -1,0 +1,60 @@
+import { createServer, Server } from "http";
+import { stringify } from "query-string";
+import { startServer } from "../server";
+
+jest.mock("http");
+
+const createMockServer = ({
+  listen,
+  close,
+}: Partial<{
+  listen: (port: number, cb: Function) => void;
+  close: (cb: Function) => void;
+}> = {}): Server => {
+  return {
+    listen: listen || ((_port: number, cb: Function) => cb()),
+    close: close || (() => {}),
+  } as unknown as Server;
+};
+
+describe("startServer()", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should create a HTTP server and when called", async () => {
+    (createServer as jest.Mock<Server>).mockImplementation(() =>
+      createMockServer()
+    );
+
+    startServer({
+      port: 3000,
+      storeRequest: () => {},
+      getInterceptedRequests: () => [],
+      onRecieveMessage: () => {},
+      onViewChange: () => {},
+    });
+
+    expect(createServer).toHaveBeenCalled();
+  });
+
+  it("should start listening when called", async () => {
+    const mockListen = jest.fn((_port: number, cb: Function) => cb());
+
+    (createServer as jest.Mock<Server>).mockImplementation(() =>
+      createMockServer({
+        listen: mockListen,
+      })
+    );
+
+    startServer({
+      port: 3000,
+      storeRequest: () => {},
+      getInterceptedRequests: () => [],
+      onRecieveMessage: () => {},
+      onViewChange: () => {},
+    });
+
+    expect(mockListen).toHaveBeenCalledWith(3000, expect.any(Function));
+  });
+});

--- a/src/util/find-text-in-block.ts
+++ b/src/util/find-text-in-block.ts
@@ -1,0 +1,13 @@
+import { HeaderBlock, KnownBlock, SectionBlock } from "@slack/types";
+
+export const findTextInBlock = (text: string) => (block: KnownBlock) => {
+  if (!["section", "header"].includes(block.type)) {
+    return false;
+  }
+
+  if (!(block as SectionBlock | HeaderBlock).text?.text.includes(text)) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
* Overhauled the 'activeView' concept to support an 'activeScreen'
* `getByText` and `interactWith` respect the active screen, and look through views or messages where appropriate
* Added a `buildTeam` fixture generator
* Documented the fixtures generator
* Now supports mentioning the app in a message via `mentionApp({ channelId: string })`, which fires the `app_mention` event under the hood